### PR TITLE
feat: remove client port from the stat metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can clone the repository to local then compile from the source, or simply ru
 go install github.com/fungaren/mtls-intercept@latest
 ```
 
-We also provide a pre-built container image `ghcr.io/fungaren/mtls-intercept:0.0.1`
+We also provide a pre-built container image `ghcr.io/fungaren/mtls-intercept:latest`
 
 ```
 Usage:
@@ -162,7 +162,7 @@ You can pass `--plugins` to the command line to enable plugins.
 |----------------|-------------------------|
 | k8sapiserver   | Count inbound/outbound bytes and requests to/from kube-apiserver, and expose Prometheus style metrics. |
 
-Contributions are welcomed.
+Contributions are welcome.
 
 ## License
 

--- a/plugins/k8sapiserver/stats.go
+++ b/plugins/k8sapiserver/stats.go
@@ -123,7 +123,7 @@ func (k *k8sAPIServerStats) OnRequest(req *http.Request, clientCert *x509.Certif
 	}
 	object := req.URL.Path
 	ua := strings.Split(req.Header.Get("User-Agent"), "/")[0]
-	source := req.RemoteAddr
+	source := strings.Split(req.RemoteAddr, ":")[0]
 	username := extractUsername(req, clientCert)
 
 	if req.ContentLength > 0 {
@@ -135,16 +135,13 @@ func (k *k8sAPIServerStats) OnRequest(req *http.Request, clientCert *x509.Certif
 }
 
 func (k *k8sAPIServerStats) OnResponse(resp *http.Response, clientCert *x509.Certificate) {
-	logger.L.Info("OnResponse Enter", zap.String("url", resp.Request.RequestURI))
-	defer logger.L.Info("OnResponse Exit", zap.String("url", resp.Request.RequestURI))
-
 	verb := resp.Request.Method
 	if strings.Index(resp.Request.RequestURI, "watch=true") > 0 {
 		verb = "WATCH"
 	}
 	object := resp.Request.URL.Path
 	ua := strings.Split(resp.Request.Header.Get("User-Agent"), "/")[0]
-	source := resp.Request.RemoteAddr
+	source := strings.Split(resp.Request.RemoteAddr, ":")[0]
 	username := extractUsername(resp.Request, clientCert)
 
 	if resp.ContentLength > 0 {


### PR DESCRIPTION
Add client port to the metric label will take too many memory, so let's remove the port.